### PR TITLE
Jvmsysprop

### DIFF
--- a/pkg/modules/configmap.go
+++ b/pkg/modules/configmap.go
@@ -44,7 +44,7 @@ func FindMetagrafConfigMaps(mg *metagraf.MetaGraf) map[string]string {
 		}
 
 		if strings.ToLower(c.Type) == "cert" {
-			fmt.Println("The Config type \"cert\" is deprected")
+			fmt.Println("The Config type \"cert\" is deprecated!")
 			os.Exit(1)
 		}
 		maps[strings.ToLower(c.Name)] = "config"

--- a/pkg/modules/configmap.go
+++ b/pkg/modules/configmap.go
@@ -42,6 +42,9 @@ func FindMetagrafConfigMaps(mg *metagraf.MetaGraf) map[string]string {
 		if strings.ToLower(c.Type) == "envref" {
 			continue
 		}
+		if strings.ToUpper(c.Type) == "JVM_SYS_PROP" {
+			continue
+		}
 
 		if strings.ToLower(c.Type) == "cert" {
 			fmt.Println("The Config type \"cert\" is deprecated!")

--- a/pkg/modules/java.go
+++ b/pkg/modules/java.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The MetaGraph Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package modules
+
+import (
+	"metagraf/pkg/metagraf"
+	"strings"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Identify if a metagraf specification has a JVM_SYS_PROP configuration type.
+// This is a special type for handling system properties in the java space that
+// your application might not know about.
+func HasJVM_SYS_PROP(mg *metagraf.MetaGraf) bool {
+	for _,c := range mg.Spec.Config {
+		if strings.ToUpper(c.Type) == "JVM_SYS_PROP" {
+			return true
+		}
+	}
+	return false
+}
+
+// Generate an EnvVar for a config section.
+// SecretFrom or EnvFrom will not be processed.
+func GenEnvVar_JVM_SYS_PROP(mg *metagraf.MetaGraf, name string) corev1.EnvVar {
+	props := []string
+	for _,c := range mg.Spec.Config {
+		if strings.ToUpper(c.Type) != "JVM_SYS_PROP" {
+			continue
+		}
+		for _,o := range c.Options {
+			if o.Required {
+				str := ""
+				// Set default value if --defaults arg is given.
+				if Defaults {
+					str = "-D" + o.Name + "=" + Variables[o.Name]
+				}
+				// Set value of key from either --cvars of --cvfile
+				if len(Variables[o.Name]) > 0  {
+					str = "-D" + o.Name + "=" + Variables[o.Name]
+				}
+				// Append generated string to props, could be empty if non of the above
+				// logic kicks in.
+				props = append(props, str)
+			}
+		}
+	}
+	return corev1.EnvVar{
+		Name: name,
+		Value: strings.Join(props, " ")
+	}
+}


### PR DESCRIPTION
This PR adds handling of a special type for Environment and Config sections:

* JVM_SYS_PROPS 

This is intended for documenting and doing configuration control of java system properties. If your base image or runtime has a way to handle -D options through en Environment variable. Set that variable as a JVM_SYS_PROP type and write a config section with type JVM_SYS_PROP to document this and can be used with standard mg configuration mechansims during manifest generation.