### PR TITLE
* Changed metagraf configuration properties format to source|key=valu…

### DIFF
--- a/mg/cmd/common.go
+++ b/mg/cmd/common.go
@@ -84,7 +84,7 @@ func PropertiesFromCmd(mgp metagraf.MGProperties) {
 
 // Used for splitting --cvfile .properties files with strings.FieldsFunc()
 func MgPropertyLineSplit(r rune) bool {
-	return r == ':' || r == '='
+	return r == '|' || r == '='
 }
 
 // Returns a map of key, value pairs that matched addressable fields
@@ -159,6 +159,10 @@ func PropertiesFromFile(mgp metagraf.MGProperties) metagraf.MGProperties {
 			if strings.Contains(line, "\n") { continue }
 		}
 		a := strings.FieldsFunc(line, MgPropertyLineSplit)
+		if len(a) != 3 {
+			fmt.Println("Configuration format error! Is it in: \"souce|key=value\"")
+			os.Exit(1)
+		}
 		t := metagraf.MGProperty{
 			Source:   a[0],
 			Key:      a[1],

--- a/mg/cmd/inspect.go
+++ b/mg/cmd/inspect.go
@@ -109,7 +109,7 @@ var InspectPropertiesCmd = &cobra.Command{
 		if fail {
 			os.Exit(1)
 		}
-		fmt.Printf("The %v confiuration is valid for this metaGraf specification.\n", CVfile)
+		fmt.Printf("The %v configuration is valid for this metaGraf specification.\n", CVfile)
 		os.Exit(0)
 	},
 }

--- a/pkg/metagraf/methods.go
+++ b/pkg/metagraf/methods.go
@@ -20,7 +20,7 @@ import "github.com/pkg/errors"
 
 // Returns a metagraf adressable key for a property.
 func (mgp *MGProperty) MGKey() string {
-	return mgp.Source+":"+mgp.Key
+	return mgp.Source+"|"+mgp.Key
 }
 
 // Returns a struct (MGProperties) of all MGProperty addressable
@@ -201,10 +201,10 @@ func (mgp MGProperties) SourceKeys(required bool) []string {
 	var keys []string
 	for _, prop := range mgp {
 		if prop.Required == required {
-			keys = append(keys, prop.Source+":"+prop.Key)
+			keys = append(keys, prop.MGKey())
 			continue
 		}
-		keys = append(keys, prop.Source+":"+prop.Key)
+		keys = append(keys, prop.MGKey())
 	}
 	return keys
 }
@@ -224,10 +224,10 @@ func (mgp MGProperties) SourceKeyMap(required bool) map[string]string {
 	keys := make(map[string]string)
 	for _, prop := range mgp {
 		if prop.Required == required {
-			keys[prop.Source+":"+prop.Key] = prop.Value
+			keys[prop.MGKey()] = prop.Value
 			continue
 		}
-		keys[prop.Source+":"+prop.Key] = prop.Value
+		keys[prop.MGKey()] = prop.Value
 	}
 	return keys
 }


### PR DESCRIPTION
…e to

ease parsing. ; caused all sorts of unexpected problems.
* Updated methods to use MGKey() function to generate source|key format.
* Added sanity check when parsing. errors out if unable to parse
  correctly.